### PR TITLE
Improve backend check

### DIFF
--- a/cmd/gotf/gotf_test.go
+++ b/cmd/gotf/gotf_test.go
@@ -127,9 +127,8 @@ myvar = value for compute
 				{
 					args: []string{"-d", "-c", "testdata/test-config.yaml", "-p", "environment=dev", "-m", "testdata/01_networking", "plan", "-input=false", "-no-color"},
 					want: []string{
-						"Configured backend does not match current environment",
-						"Got: .terraform/terraform-networking-prod.tfstate",
-						"Want: .terraform/terraform-networking-dev.tfstate",
+						"configured backend does not match current environment",
+						"path: got=.terraform/terraform-networking-prod.tfstate, want=.terraform/terraform-networking-dev.tfstate",
 						"Run terraform init -reconfigure!",
 					},
 					wantErr: true,


### PR DESCRIPTION
We now display all changed values in the error message instead of only
the first one. Also, `%v` is used for formatting instead of `%s` which has
a friendlier output for missing values (`<nil>` instead of `%!s(<nil>)`).