### PR TITLE
Allow hermetic Sprig funtions only

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ backendConfigs:
 ### Templating
 
 Go templating can be used in the config file as follows.
-The [Sprig](https://masterminds.github.io/sprig/) function library is included.
+Hermetic, i.e. repeatable, functions from the [Sprig](https://masterminds.github.io/sprig/) function library are included.
 
 * In the first templating pass, `globalVarFiles`, `globalVars`, `moduleVarFiles`, `moduleVars`, and `envs` are processed.
   All parameters specified under `params` and using the `-p|--param` flag are available in the `.Params` object.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -186,7 +186,7 @@ func load(cfgData []byte) (*fileConfig, error) {
 
 func renderTemplate(data map[string]interface{}, tmpl string) (string, error) {
 	wr := strings.Builder{}
-	tpl := template.New("gotpl").Funcs(sprig.TxtFuncMap()).Option("missingkey=error")
+	tpl := template.New("gotpl").Funcs(sprig.HermeticTxtFuncMap()).Option("missingkey=error")
 	tpl, err := tpl.Parse(tmpl)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Only repeatable functions should be available. Otherwise it would be
possible to create different values on different Terraform runs which
doesn't make sense because it's out of Terraform's control and would
break Terraform's idempotency.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>