### PR TITLE
Move Terraform args check

### DIFF
--- a/cmd/gotf/gotf.go
+++ b/cmd/gotf/gotf.go
@@ -15,7 +15,6 @@
 package gotf
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -59,12 +58,6 @@ func newGotfCommand() *cobra.Command {
 gotf is a Terraform wrapper facilitating configurations for various environments
 `, fullVersion),
 		Version: fullVersion,
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 1 {
-				return errors.New("no arguments for Terraform specified")
-			}
-			return nil
-		},
 		RunE: func(command *cobra.Command, args []string) error {
 			return gotf.Run(gotf.Args{
 				Debug:      debug,

--- a/pkg/gotf/gotf.go
+++ b/pkg/gotf/gotf.go
@@ -15,6 +15,7 @@
 package gotf
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -80,6 +81,10 @@ type Args struct {
 }
 
 func Run(args Args) error {
+	if len(args.Args) == 0 {
+		return errors.New("no arguments for Terraform specified")
+	}
+
 	if args.Debug {
 		log.SetOutput(os.Stderr)
 		log.SetFlags(0)


### PR DESCRIPTION
The check came too early and would hide Cobra's check for required args.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>