### PR TITLE
Add option to skip variables

### DIFF
--- a/cmd/gotf/gotf.go
+++ b/cmd/gotf/gotf.go
@@ -45,6 +45,7 @@ func newGotfCommand() *cobra.Command {
 	var debug bool
 	var moduleDir string
 	var skipBackendCheck bool
+	var noVars bool
 
 	fullVersion := fmt.Sprintf("%s (commit=%s, date=%s)", gotf.Version, gotf.GitCommit, gotf.BuildDate)
 	command := &cobra.Command{
@@ -66,6 +67,7 @@ gotf is a Terraform wrapper facilitating configurations for various environments
 				ModuleDir:        moduleDir,
 				Params:           params.GetAll(),
 				SkipBackendCheck: skipBackendCheck,
+				NoVars:           noVars,
 				Args:             args,
 			})
 		},
@@ -76,6 +78,8 @@ gotf is a Terraform wrapper facilitating configurations for various environments
 	command.Flags().BoolVarP(&debug, "debug", "d", false, "Print additional debug output to stderr")
 	command.Flags().StringVarP(&moduleDir, "module-dir", "m", "", "The module directory to run Terraform in")
 	command.Flags().BoolVarP(&skipBackendCheck, "skip-backend-check", "s", false, "Skip checking for changed backend configuration")
+	command.Flags().BoolVarP(&noVars, "no-vars", "n", false, `Don't add any variables when running Terraform.
+This is necessary when running 'terraform apply' with a plan file.`)
 	command.Flags().SetInterspersed(false)
 	command.SetVersionTemplate("{{ .Version }}\n")
 	command.SilenceUsage = true

--- a/cmd/gotf/gotf_test.go
+++ b/cmd/gotf/gotf_test.go
@@ -174,6 +174,28 @@ myvar = "value for compute"
 				},
 			},
 		},
+		{
+			name: "no-vars",
+			runs: []testRun{
+				{
+					args: []string{"-d", "-c", "testdata/test-config.yaml", "-p", "environment=dev", "-m", "testdata/01_networking", "init", "-no-color"},
+					want: []string{"Terraform has been successfully initialized!"},
+				},
+				{
+					args: []string{"-d", "-c", "testdata/test-config.yaml", "-p", "environment=dev", "-m", "testdata/01_networking", "plan", "-input=false", "-no-color", "-out=plan.out"},
+					want: []string{
+						"# null_resource.echo will be created",
+						"Plan: 1 to add, 0 to change, 0 to destroy.",
+					},
+				},
+				{
+					args: []string{"-d", "-c", "testdata/test-config.yaml", "-p", "environment=dev", "-m", "testdata/01_networking", "--no-vars", "apply", "-no-color", "plan.out"},
+					want: []string{
+						"Apply complete!",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -185,7 +207,9 @@ myvar = "value for compute"
 
 			t.Cleanup(func() {
 				os.RemoveAll("testdata/01_networking/.terraform")
+				os.RemoveAll("testdata/01_networking/plan.out")
 				os.RemoveAll("testdata/02_compute/.terraform")
+				os.RemoveAll("testdata/02_compute/plan.out")
 				os.Remove("testdata/01_networking/.terraform.lock.hcl")
 				os.Remove("testdata/02_compute/.terraform.lock.hcl")
 			})

--- a/pkg/gotf/gotf.go
+++ b/pkg/gotf/gotf.go
@@ -78,6 +78,7 @@ type Args struct {
 	ModuleDir        string
 	Params           map[string]string
 	SkipBackendCheck bool
+	NoVars           bool
 	Args             []string
 }
 
@@ -126,6 +127,6 @@ func Run(args Args) error {
 	log.Println("Terraform binary:", tfBinary)
 
 	shell := sh.Shell{}
-	tf := terraform.NewTerraform(cfg, args.ModuleDir, args.Params, args.SkipBackendCheck, shell, tfBinary)
+	tf := terraform.NewTerraform(cfg, args.ModuleDir, args.Params, args.SkipBackendCheck, args.NoVars, shell, tfBinary)
 	return tf.Execute(args.Args...)
 }


### PR DESCRIPTION
Adds the `--no-vars` option. When this option is set, no variables
are passed to Terraform. This is necessary whe running `terraform apply`
with a plan file, which already includes all variables.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>