### PR TITLE
Remove non-functional cache dir change for tests

### DIFF
--- a/cmd/gotf/gotf_test.go
+++ b/cmd/gotf/gotf_test.go
@@ -17,7 +17,6 @@ package gotf
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -197,14 +196,9 @@ myvar = "value for compute"
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("testdata", "gotf")
-			t.Cleanup(func() { os.RemoveAll(tempDir) })
-
-			panicOnError(err)
-			panicOnError(os.Setenv("XDG_CACHE_HOME", filepath.Join(tempDir, "tfcache")))
-
 			t.Cleanup(func() {
 				os.RemoveAll("testdata/01_networking/.terraform")
 				os.RemoveAll("testdata/01_networking/plan.out")
@@ -226,12 +220,6 @@ myvar = "value for compute"
 				}
 			}
 		})
-	}
-}
-
-func panicOnError(err error) {
-	if err != nil {
-		panic(err)
 	}
 }
 

--- a/pkg/tf/installer_test.go
+++ b/pkg/tf/installer_test.go
@@ -15,7 +15,6 @@
 package terraform
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -56,12 +55,7 @@ kdbIIs9rDtIWEXh/SeiWWwyV+fzsWRMttw86f/GTrGuMiSz9bV3J6KBuf1ymd6OU
 `)
 
 func TestInstaller_Install(t *testing.T) {
-	dir, err := ioutil.TempDir("", "gotf")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	transport := &http.Transport{}
 	cwd, _ := os.Getwd()
 	transport.RegisterProtocol("file", http.NewFileTransport(http.Dir(cwd)))
@@ -75,7 +69,7 @@ func TestInstaller_Install(t *testing.T) {
 	installer := NewInstaller(urlTemplates, "0.42.0", [][]byte{testGPGPublicKey}, dir)
 	installer.httpClient = httpClient
 
-	err = installer.Install()
+	err := installer.Install()
 	assert.NoError(t, err)
 	assert.FileExists(t, filepath.Join(dir, "test.txt"))
 }


### PR DESCRIPTION
Setting XDG_CACHE_HOME to a temporary directory for tests did not work
because the directory is initialized in an init function. Setting the
environment variable comes to late. We'd have to explicitly call
xdg.Reload() to fix this. However, we can just remove this. On CI, the
Terraform binary is never cached anyways, and locally we want it to be
cached in the default directory so tests run fast. Having to download
Terraform on every test execution would be painful.